### PR TITLE
When activation is missing, do not emit a log message

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-flask/src/opentelemetry/instrumentation/flask/__init__.py
@@ -156,11 +156,9 @@ def _teardown_request(exc):
 
     activation = flask.request.environ.get(_ENVIRON_ACTIVATION_KEY)
     if not activation:
-        _logger.warning(
-            "Flask environ's OpenTelemetry activation missing"
-            "at _teardown_flask_request(%s)",
-            exc,
-        )
+        # This request didn't start a span, maybe because it was created in a
+        # way that doesn't run `before_request`, like when it is created with
+        # `app.test_request_context`.
         return
 
     if exc is None:


### PR DESCRIPTION
If a Flask request doesn't have an active span, it just means that it was initialized via a mechanism that doesn't run `before_request`, like `app.test_request_context` or even manually. It is okay and instrumentation still works.